### PR TITLE
Update dbus to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,4 @@ categories = ["os::unix-apis"]
 keywords = ["linux", "systemd", "logind", "dbus"]
 
 [dependencies]
-dbus = "0.6"
-cascade = "0.1.2"
+dbus = "0.8"


### PR DESCRIPTION
This updates the `dbus` dependency to `0.8`. The dependency on `cascade` is now unnecessary because of the improved `dbus` API.